### PR TITLE
Protect adapter Write() with a mutex for concurrent use

### DIFF
--- a/pkg/wsconnadapter/wsconnadapter.go
+++ b/pkg/wsconnadapter/wsconnadapter.go
@@ -13,9 +13,10 @@ import (
 // some caveats apply: https://github.com/gorilla/websocket/issues/441
 
 type Adapter struct {
-	conn      *websocket.Conn
-	readMutex sync.Mutex
-	reader    io.Reader
+	conn       *websocket.Conn
+	readMutex  sync.Mutex
+	writeMutex sync.Mutex
+	reader     io.Reader
 }
 
 func New(conn *websocket.Conn) *Adapter {
@@ -58,6 +59,9 @@ func (a *Adapter) Read(b []byte) (int, error) {
 }
 
 func (a *Adapter) Write(b []byte) (int, error) {
+	a.writeMutex.Lock()
+	defer a.writeMutex.Unlock()
+
 	nextWriter, err := a.conn.NextWriter(websocket.BinaryMessage)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Hi, @joonas-fi

Thanks a lot for making this adapter available! When trying to use it, we noticed that attempting to Write from multiple goroutines causes a panic:

```
panic: concurrent write to websocket connection

goroutine 50 [running]:
github.com/gorilla/websocket.(*messageWriter).flushFrame(0xc00025a270, 0x1, 0x0, 0x0, 0x0, 0x8, 0x0)
    /go/pkg/mod/github.com/gorilla/websocket@v1.4.0/conn.go:591 +0x77c
github.com/gorilla/websocket.(*messageWriter).Close(0xc00025a270, 0x7fad682b0000, 0x0)
    /go/pkg/mod/github.com/gorilla/websocket@v1.4.0/conn.go:709 +0x56
github.com/gorilla/websocket.(*Conn).prepWrite(0xc000088c60, 0x2, 0x1, 0x8)
    /go/pkg/mod/github.com/gorilla/websocket@v1.4.0/conn.go:459 +0x214
github.com/gorilla/websocket.(*Conn).NextWriter(0xc000088c60, 0x2, 0x0, 0x0, 0x0, 0x1)
    /go/pkg/mod/github.com/gorilla/websocket@v1.4.0/conn.go:494 +0x39
github.com/function61/holepunch-server/pkg/wsconnadapter.(*Adapter).Write(0xc00000b0e0, 0xc000106f70, 0x6, 0x40, 0xc000106f72, 0xc000106e90, 0x4)
    /go/pkg/mod/github.com/function61/holepunch-server@v0.0.0-20181030103722-63c4b820d6db/pkg/wsconnadapter/wsconnadapter.go:61 +0x3b
bytes.(*Buffer).WriteTo(0xc000106ee0, 0x7fad65ea8378, 0xc00000b0e0, 0x40, 0x4, 0x0)
    /usr/local/go/src/bytes/buffer.go:241 +0xb6
...
```

Please consider merging in the proposed small change. I am also open for feedback!

Cheers!